### PR TITLE
SWPY-1074-change-error_view-functionality

### DIFF
--- a/spynl/main/endpoints.py
+++ b/spynl/main/endpoints.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 from spynl.main.utils import get_user_info
-from spynl.main.exceptions import SpynlException
 from spynl.main.dateutils import now, localize_date, date_to_str
 
 

--- a/spynl/main/endpoints.py
+++ b/spynl/main/endpoints.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 from spynl.main.utils import get_user_info
+from spynl.main.exceptions import SpynlException
 from spynl.main.dateutils import now, localize_date, date_to_str
 
 

--- a/spynl/main/error_views.py
+++ b/spynl/main/error_views.py
@@ -6,7 +6,6 @@ from pyramid.security import ACLDenied
 from pyramid.httpexceptions import (HTTPForbidden, HTTPNotFound,
                                     HTTPInternalServerError)
 
-from spynl.main.exceptions import SpynlException
 from spynl.main.utils import log_error
 from spynl.main.locale import SpynlTranslationString as _
 
@@ -26,9 +25,7 @@ def spynl_error(exc, request):
     top_msg = "Spynl Error of type %s with message: '%s'."
     message = exc.message
     log_error(exc, request, top_msg, exc.__class__.__name__, message)
-    return {'status': 'error',
-            'type': exc.__class__.__name__,
-            'message': message}
+    return exc.make_response()
 
 
 def error400(exc, request):
@@ -54,7 +51,7 @@ def error400(exc, request):
             message = _(
                 'permission-denial',
                 default="Permission to '${permission}' ${context} was denied.",
-                mapping={'context':request.context.__class__.__name__,
+                mapping={'context': request.context.__class__.__name__,
                          'permission': exc.result.permission})
             emeta = exc.result  # TODO: log this as detail info
         else:

--- a/spynl/main/exceptions.py
+++ b/spynl/main/exceptions.py
@@ -19,11 +19,33 @@ class SpynlException(Exception):
     def __init__(self, message='an internal error has occured'):
         self.message = message
 
-    def __str__(self):
+    def make_response(self):
         """
-        This will return a str version of the message. If the message is a
+        Return a response as a dictionary.
+
+        If an exception needs to store additional information in the reponse
+        it can be overriden in the following way.
+
+        >>> def make_reponse(self):
+                data = super().make_response()
+                data.update({
+                    'extra': 'Some extra information'
+                })
+                return data
+        """
+        response = {
+            'status': 'error',
+            'type': self.__class__.__name__,
+            'message': self.message
+        }
+
+        return response
+
+    def __str__(self):
+        """This will return a str version of the message. If the message is a
         SpynlTranslationString, it will return an interpolated version of the
-        default (no translation). """
+        default (no translation).
+        """
         return str(self.message)
 
 

--- a/spynl/tests/test_exception.py
+++ b/spynl/tests/test_exception.py
@@ -1,0 +1,47 @@
+"""Test functions from spynl.main."""
+import pytest
+
+from spynl.main.exceptions import SpynlException
+
+
+@pytest.fixture
+def exception_app(app_factory, settings, monkeypatch):
+    '''Plugin an endpoint that always raises and echo's back information.'''
+
+    def patched_plugin_main(config):
+        def echo_raise(request):
+            '''Always raises.
+
+            If some information is passes in the query params it is included within
+            the reponse.
+            '''
+            if request.GET:
+                class CustomException(SpynlException):
+                    def make_response(self):
+                        data = super().make_response()
+                        data.update(request.GET)
+                        return data
+
+                raise CustomException
+            raise SpynlException
+
+        config.add_endpoint(echo_raise, 'echo-raise')
+
+    # monkeypatch spynl.main.plugins.main as it is a simple entry point without
+    # internal logic where normally external plugins would get included.
+    monkeypatch.setattr('spynl.main.plugins.main', patched_plugin_main)
+    app = app_factory(settings)
+
+    return app
+
+
+def test_spynlexception(exception_app):
+    """Test regular SpynlException"""
+    response = exception_app.get('/echo-raise', expect_errors=True)
+    assert response.json == SpynlException().make_response()
+
+
+def test_overridden_spynlexception(exception_app):
+    """Test regular SpynlException"""
+    response = exception_app.get('/echo-raise', params={'custom': 'blah'}, expect_errors=True)
+    assert response.json.get('custom') == 'blah'

--- a/spynl/tests/test_exception.py
+++ b/spynl/tests/test_exception.py
@@ -6,15 +6,16 @@ from spynl.main.exceptions import SpynlException
 
 @pytest.fixture
 def exception_app(app_factory, settings, monkeypatch):
-    '''Plugin an endpoint that always raises and echo's back information.'''
+    """Plugin an endpoint that always raises and echo's back information."""
 
     def patched_plugin_main(config):
         def echo_raise(request):
-            '''Always raises.
+            """
+            Always raises.
 
-            If some information is passes in the query params it is included within
-            the reponse.
-            '''
+            If some information is passes in the query params it is included
+            within the reponse.
+            """
             if request.GET:
                 class CustomException(SpynlException):
                     def make_response(self):

--- a/spynl/tests/test_exception.py
+++ b/spynl/tests/test_exception.py
@@ -43,6 +43,6 @@ def test_spynlexception(exception_app):
 
 
 def test_overridden_spynlexception(exception_app):
-    """Test regular SpynlException"""
+    """Test overridden SpynlException"""
     response = exception_app.get('/echo-raise', params={'custom': 'blah'}, expect_errors=True)
     assert response.json.get('custom') == 'blah'


### PR DESCRIPTION
Added a "make_response" function to SpynlException. I called it
make_response because just "response" is not a verb. At first I
implemented response as a property but that doesn't play nice with
super.

spynl_error calls it now and there are tests.