### PR TITLE
Kareem/swpy 1079 simplify the call to log error

### DIFF
--- a/spynl/main/error_views.py
+++ b/spynl/main/error_views.py
@@ -24,8 +24,8 @@ def spynl_error(exc, request):
     request.response.content_type = 'application/json'  # this is Spynl default
 
     top_msg = "Spynl Error of type %s with message: '%s'."
+    log_error(exc, request, top_msg)
     message = exc.message
-    log_error(exc, request, top_msg, exc.__class__.__name__, message)
     return {'status': 'error',
             'type': exc.__class__.__name__,
             'message': message}
@@ -70,12 +70,8 @@ def error400(exc, request):
             else:
                 message = exc.detail
 
-    if error_type.endswith('Exception'):
-        error_type = error_type[:-len('Exception')]
-
     top_msg = "HTTP Error of type %s with message: '%s'."
-
-    log_error(exc, request, top_msg, error_type, message)
+    log_error(exc, request, top_msg, error_type=error_type, error_msg=message)
 
     response = {'status': 'error', 'type': error_type, 'message': message}
     if hasattr(exc, 'details') and exc.details:
@@ -96,17 +92,8 @@ def error500(exc, request):
     request.response.status_int = 500
     request.response.content_type = 'application/json'  # this is Spynl default
 
-    message = str(exc)
-    if not message:
-        message = _('no-message-available', default="No message available.")
-
-    error_type = exc.__class__.__name__
-    if error_type.endswith('Exception'):
-        error_type = error_type[:-len('Exception')]
-
     top_msg = "Server Error (500) of type '%s' with message: '%s'."
-
-    log_error(exc, request, top_msg, error_type, message)
+    log_error(exc, request, top_msg)
 
     message = _('internal-server-error',
                 default='An internal server error occured.')

--- a/spynl/main/exceptions.py
+++ b/spynl/main/exceptions.py
@@ -16,8 +16,9 @@ class SpynlException(Exception):
     """
     http_escalate_as = HTTPBadRequest
 
-    def __init__(self, message='an internal error has occured'):
+    def __init__(self, message='an internal error has occured', debug_message=None):
         self.message = message
+        self.debug_message = debug_message or self.message
 
     def __str__(self):
         """

--- a/spynl/main/utils.py
+++ b/spynl/main/utils.py
@@ -8,12 +8,10 @@ import sys
 import os
 import contextlib
 from functools import wraps
-from inspect import isfunction, isclass, getargspec
-from collections import namedtuple
+from inspect import isclass, getargspec
 import yaml
 from tld import get_tld
 from tld.exceptions import TldBadUrl, TldDomainNotFound
-import inspect
 
 from pyramid.response import Response
 from pyramid.renderers import json_renderer_factory
@@ -24,7 +22,6 @@ from spynl.main import urlson
 from spynl.main.exceptions import SpynlException, MissingParameter, BadOrigin
 from spynl.main.version import __version__ as spynl_version
 from spynl.main.locale import SpynlTranslationString as _
-
 
 
 def get_request():
@@ -215,8 +212,7 @@ def find_view_name(request):
     if name.startswith('/'):
         name = name[1:]
 
-    if hasattr(request, 'matched_route')\
-      and request.matched_route:
+    if hasattr(request, 'matched_route') and request.matched_route:
         if name in request.matched_route.name:
             # method  name was not in the URL
             if request.method == 'POST':
@@ -298,7 +294,6 @@ def is_package_installed(package_name):
     return package_name in [i.key for i in pip.get_installed_distributions()]
 
 
-
 def get_logger(name=None):
     """Return the Logger object with the given name."""
     if not name:
@@ -339,7 +334,6 @@ def parse_value(value, class_info):
         default='"${value}" could not be parsed into any class in ${classes}',
         mapping={'value': value,
                  'classes': [cl.__name__ for cl in class_info]}))
-
 
 
 def parse_csv_list(csv_list):

--- a/spynl/main/utils.py
+++ b/spynl/main/utils.py
@@ -469,6 +469,7 @@ def log_error(exc, request, top_msg, error_type=None, error_msg=None):
 
     metadata = dict(user=user_info,
                     url=request.path_url,
+                    debug_message=getattr(exc, 'debug_message', 'No debug message'),
                     err_source=get_err_source(last_traceback),
                     detail=getattr(exc, 'detail', None))
 

--- a/spynl/tests/test_log_error.py
+++ b/spynl/tests/test_log_error.py
@@ -1,0 +1,138 @@
+"""Test functions from spynl.main."""
+import pytest
+
+from spynl.main.utils import log_error
+
+
+@pytest.fixture
+def logger(monkeypatch):
+    """Patch a number of things so we can return a logger and not have any
+    external things going on.
+    """
+    def patched_get_user_info(*args, **kwargs):
+        return dict(ipaddress='127.0.0.1')
+    monkeypatch.setattr('spynl.main.utils.get_user_info', patched_get_user_info)
+
+    def patched_monitoring(*args, **kwargs):
+        pass
+    monkeypatch.setattr('spynl.main.utils.send_exception_to_external_monitoring',
+                        patched_monitoring)
+
+    class Logger:
+        """This logger will simply set an attribute to easily inspect was has
+        been passed to it.
+        """
+
+        def __init__(self):
+            self.error_log = None
+
+        def error(self, msg, *args, **kwargs):
+            self.error_log = {
+                'msg': msg % args,
+                'kwargs': kwargs
+            }
+
+    logger = Logger()
+
+    def patched_getLogger(name):
+        return logger
+    monkeypatch.setattr('logging.getLogger', patched_getLogger)
+
+    return logger
+
+
+@pytest.fixture
+def fake_request():
+    """Return a fake request."""
+    class FakeRequest:
+        path_url = '/fake'
+        body = 'fake request'
+
+    return FakeRequest()
+
+
+TOP_MSG = "TEST Error of type %s with message: '%s'."
+
+
+def test_log_error_msg(logger, fake_request):
+    class Error(Exception):
+        def __str__(self):
+            return "An error has occurred"
+
+    try:
+        raise Error
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+        assert logger.error_log['msg'] == TOP_MSG % ('Error', 'An error has occurred')
+
+
+def test_log_error_msg_attribute(logger, fake_request):
+    class Error(Exception):
+        message = 'An error has occurred'
+
+    try:
+        raise Error
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+        assert logger.error_log['msg'] == TOP_MSG % ('Error', 'An error has occurred')
+
+
+def test_log_exception_cause(logger, fake_request):
+    """Test that when a second exception is raised from the context of a first
+    the logger receives information about the original.
+    """
+
+    class Error(Exception):
+        pass
+
+    class SecondError(Exception):
+        pass
+
+    try:
+        raise Error
+    except Exception as exc:
+        try:
+            raise SecondError from exc
+        except Exception as exc2:
+            log_error(exc2, fake_request, TOP_MSG)
+            assert logger.error_log['kwargs']['exc_info'][0] == Error
+
+
+def test_log_exception_name(logger, fake_request):
+    """Test that when a second exception is raised from the context of a first
+    the logger receives information about the original.
+    """
+
+    class SomeException(Exception):
+        pass
+
+    try:
+        raise SomeException
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+        assert 'Exception' not in logger.error_log['msg']
+
+
+def test_log_exception_default_message(logger, fake_request):
+    """Test that when the exception has no .message or str(Exc) returns
+    an empty string the default message is logged.
+    """
+
+    try:
+        raise Exception
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+        assert 'No message available' in logger.error_log['msg']
+
+
+def test_log_given_exc_type_and_msg(logger, fake_request):
+    """Test that the given error_type and msg are used."""
+
+    try:
+        raise Exception
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG,
+                  error_type="Argh", error_msg="what the hell")
+
+        assert logger.error_log['msg'] == ("TEST Error of type Argh "
+                                           "with message: 'what the hell'.")

--- a/spynl/tests/test_log_error.py
+++ b/spynl/tests/test_log_error.py
@@ -6,8 +6,11 @@ from spynl.main.utils import log_error
 
 @pytest.fixture
 def logger(monkeypatch):
-    """Patch a number of things so we can return a logger and not have any
-    external things going on.
+    """
+    Patch calls to the outside.
+
+    Don't care about real user info, monitoring and we want a logger that
+    we can easily inspect.
     """
     def patched_get_user_info(*args, **kwargs):
         return dict(ipaddress='127.0.0.1')
@@ -19,9 +22,7 @@ def logger(monkeypatch):
                         patched_monitoring)
 
     class Logger:
-        """This logger will simply set an attribute to easily inspect was has
-        been passed to it.
-        """
+        """This logger will set the passed information on self.error_log"""
 
         def __init__(self):
             self.error_log = None
@@ -55,6 +56,7 @@ TOP_MSG = "TEST Error of type %s with message: '%s'."
 
 
 def test_log_error_msg(logger, fake_request):
+    """Test casting the exception to string."""
     class Error(Exception):
         def __str__(self):
             return "An error has occurred"
@@ -67,6 +69,7 @@ def test_log_error_msg(logger, fake_request):
 
 
 def test_log_error_msg_attribute(logger, fake_request):
+    """Test that the .message attr is passed correctly."""
     class Error(Exception):
         message = 'An error has occurred'
 
@@ -78,7 +81,10 @@ def test_log_error_msg_attribute(logger, fake_request):
 
 
 def test_log_exception_cause(logger, fake_request):
-    """Test that when a second exception is raised from the context of a first
+    """
+    Test exception __cause__
+
+    Test that when a second exception is raised from the context of a first
     the logger receives information about the original.
     """
 
@@ -99,9 +105,7 @@ def test_log_exception_cause(logger, fake_request):
 
 
 def test_log_exception_name(logger, fake_request):
-    """Test that when a second exception is raised from the context of a first
-    the logger receives information about the original.
-    """
+    """Test stripping of "Exception" from the name."""
 
     class SomeException(Exception):
         pass
@@ -114,8 +118,11 @@ def test_log_exception_name(logger, fake_request):
 
 
 def test_log_exception_default_message(logger, fake_request):
-    """Test that when the exception has no .message or str(Exc) returns
-    an empty string the default message is logged.
+    """
+    Test default message.
+
+    When the exception has no .message or str(Exc) returns
+    an empty string the default message should be logged.
     """
 
     try:

--- a/spynl/tests/test_log_error.py
+++ b/spynl/tests/test_log_error.py
@@ -143,3 +143,18 @@ def test_log_given_exc_type_and_msg(logger, fake_request):
 
         assert logger.error_log['msg'] == ("TEST Error of type Argh "
                                            "with message: 'what the hell'.")
+
+
+def test_log_debug_message(logger, fake_request):
+    """Test that the debug_message is logged."""
+
+    class SomeException(Exception):
+        debug_message = "Debug this."
+
+    try:
+        raise SomeException
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+
+        assert (logger.error_log['kwargs']['extra']['meta']['debug_message'] ==
+                SomeException.debug_message)

--- a/spynl/tests/test_log_error.py
+++ b/spynl/tests/test_log_error.py
@@ -2,6 +2,7 @@
 import pytest
 
 from spynl.main.utils import log_error
+from spynl.main.exceptions import SpynlException
 
 
 @pytest.fixture
@@ -145,16 +146,57 @@ def test_log_given_exc_type_and_msg(logger, fake_request):
                                            "with message: 'what the hell'.")
 
 
-def test_log_debug_message(logger, fake_request):
-    """Test that the debug_message is logged."""
-
-    class SomeException(Exception):
-        debug_message = "Debug this."
+def test_log_message(logger, fake_request):
+    """Test that the default spynlmessage is logged."""
 
     try:
-        raise SomeException
+        raise SpynlException
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+
+        assert SpynlException().message in logger.error_log['msg']
+
+
+def test_log_debug_message(logger, fake_request):
+    """Test that the default debug_message is logged."""
+
+    try:
+        raise SpynlException
     except Exception as exc:
         log_error(exc, fake_request, TOP_MSG)
 
         assert (logger.error_log['kwargs']['extra']['meta']['debug_message'] ==
-                SomeException.debug_message)
+                SpynlException().debug_message)
+
+
+def test_log_custom_message(logger, fake_request):
+    """Test that the debug_message is logged."""
+
+    try:
+        raise SpynlException(message="blah")
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+
+        assert "blah" in logger.error_log['msg']
+
+
+def test_log_custom_debug_message(logger, fake_request):
+    """Test that the debug_message is logged."""
+
+    try:
+        raise SpynlException(debug_message="blah")
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+
+        assert logger.error_log['kwargs']['extra']['meta']['debug_message'] == "blah"
+
+
+def test_log_message_equals_debug_message(logger, fake_request):
+    """Test that the default spynlmessage is logged."""
+
+    try:
+        raise SpynlException
+    except Exception as exc:
+        log_error(exc, fake_request, TOP_MSG)
+
+        logger.error_log['msg'] == logger.error_log['kwargs']['extra']['meta']['debug_message']


### PR DESCRIPTION
This PR moves the logic of parsing exceptions for logging to the log_error function. 

There is one potential issue  that was already there. Namely that when the `top_msg` format string does not contain exactly 2 placeholders. An uncaught exception is raised. Not a big deal but this constraint could be enforced somehow.