### PR TITLE
Revert back to pythons stdlib json.

### DIFF
--- a/spynl/cli/ops/docker/Dockerfile
+++ b/spynl/cli/ops/docker/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
-MAINTAINER Nicolas Hï¿½ning <nicolas@softwear.nl>
+MAINTAINER Nicolas Höning <nicolas@softwear.nl>
 
 RUN apt-get update -qq && apt-get install -y --no-install-recommends python3.5 python3-pip python-pip supervisor sudo && apt-get autoremove -y && apt-get clean -y && mkdir /logs
 
 COPY supervisord.conf /etc/supervisord.conf
-COPY production.ini /production.ini
+COPY production.ini /production.ini 
 COPY deployment-key /root/deployment-key
 COPY setup.sh setup.sh
 RUN apt-get update -q && apt-get install -y git mercurial && ./setup.sh && apt-get autoremove -y && apt-get clean -y

--- a/spynl/main/dateutils.py
+++ b/spynl/main/dateutils.py
@@ -14,14 +14,14 @@ def now(tz=None):
     return localize_date(datetime.utcnow(), tz=tz)
 
 
-def spynl_date_format():
+def date_format_str():
     """Get the date format from the .ini file, or set default."""
     return get_settings().get('spynl.date_format', '%Y-%m-%dT%H:%M:%S%z')
 
 
 def date_to_str(when):
     """Convert date to string according to settings format"""
-    return when.strftime(spynl_date_format())
+    return when.strftime(date_format_str())
 
 
 def date_from_str(dstr):

--- a/spynl/main/serial/__init__.py
+++ b/spynl/main/serial/__init__.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.settings import asbool
 
-from spynl.main.serial.typing import CONTENT_TYPE_HANDLERS
+from spynl.main.serial.typing import handlers
 from spynl.main.serial.typing import negotiate_response_content_type
 from spynl.main.serial.exceptions import (UndeterminedContentTypeException,
                                           UnsupportedContentTypeException,
@@ -29,7 +29,7 @@ from spynl.main.serial.exceptions import (UndeterminedContentTypeException,
                                           DeserializationUnsupportedException,
                                           MalformedRequestException)
 from spynl.main.serial.objects import (add_decode_function, decode_date,
-                                       add_encode_function,
+                                       add_encode_function, encode_boolean,
                                        encode_date,
                                        encode_spynl_translation_string)
 from spynl.main.locale import SpynlTranslationString
@@ -39,8 +39,8 @@ def parse_post_data(request):
     """Parse data according to the requests content type."""
     try:
         context = hasattr(request, 'context') and request.context or None
-        parsed_body = load_by_content_type(request.text, request.content_type,
-                                           request.headers, context)
+        parsed_body = loads(request.text, request.content_type,
+                            request.headers, context)
     except MalformedRequestException as e:
         raise HTTPBadRequest(detail=e.message.translate(request.localizer))
 
@@ -66,8 +66,7 @@ def renderer(values, system):
 
     pretty = asbool(r.registry.settings.get('spynl.pretty'))
     try:
-        response = dump_by_content_type(values, r.response.content_type,
-                                        pretty=pretty)
+        response = dumps(values, r.response.content_type, pretty=pretty)
     except UnsupportedContentTypeException as e:
         raise UndeterminedContentTypeException(str(e))
 
@@ -77,10 +76,10 @@ def renderer(values, system):
 # ---- high-level dumps and loads functions,
 #      relay to specific dumps and loads per type
 
-def dump_by_content_type(body, content_type, pretty=False):
+def dumps(body, content_type, pretty=False):
     """Relay to content-type specific dumping."""
     try:
-        handler = CONTENT_TYPE_HANDLERS[content_type]
+        handler = handlers[content_type]
     except KeyError:
         raise UnsupportedContentTypeException(content_type)
 
@@ -92,13 +91,13 @@ def dump_by_content_type(body, content_type, pretty=False):
     return dump(body, pretty=pretty)
 
 
-def load_by_content_type(body, content_type, headers=None, context=None):
+def loads(body, content_type, headers=None, context=None):
     """Relay to content-type specific load."""
     if not body:
         return {}
 
     try:
-        handler = CONTENT_TYPE_HANDLERS[content_type]
+        handler = handlers[content_type]
     except KeyError:
         raise UnsupportedContentTypeException(content_type)
 
@@ -122,5 +121,6 @@ def main(config):
     add_decode_function(config, decode_date, ['date'])
     # define encoding functions
     add_encode_function(config, encode_date, datetime)
+    add_encode_function(config, encode_boolean, bool)
     add_encode_function(config, encode_spynl_translation_string,
                         SpynlTranslationString)

--- a/spynl/main/serial/cli.py
+++ b/spynl/main/serial/cli.py
@@ -3,8 +3,7 @@
 from sys import stdin, stdout
 from argparse import ArgumentParser
 
-from spynl.main.serial import (negotiate_content_type, load_by_content_type,
-                               dump_by_content_type)
+from spynl.main.serial import negotiate_content_type, loads, dumps
 
 
 def main():
@@ -24,10 +23,8 @@ def main():
 
     request = stdin.read()
 
-    request = load_by_content_type(
-        request, negotiate_content_type(request, args.input_type))
-    response = dump_by_content_type(
-        request, negotiate_content_type('', args.output_type))
+    request = loads(request, negotiate_content_type(request, args.input_type))
+    response = dumps(request, negotiate_content_type('', args.output_type))
 
     output = open(args.output_filename, 'w')\
         if args.output_filename else stdout

--- a/spynl/main/serial/json.py
+++ b/spynl/main/serial/json.py
@@ -18,12 +18,13 @@ def loads(body, headers=None, context=None):
 
 def dumps(body, pretty=False):
     """Return JSON body as string."""
-    indent = None if pretty is False else 4
+    indent = None
+    if pretty:
+        indent = 4
 
     class JSONEncoder(json.JSONEncoder):
         def default(self, obj):  # pylint: disable=method-hidden
             return objects.encode(obj)
-
     return json.dumps(body, indent=indent, ensure_ascii=False, cls=JSONEncoder)
 
 

--- a/spynl/tests/test_responses.py
+++ b/spynl/tests/test_responses.py
@@ -90,10 +90,12 @@ def test_bad_json(app):
     """Test that bad json in the request raises exceptions."""
     headers = {'Content-Type': 'application/json'}
 
-    with pytest.raises_regexp(AppError, 'Expecting value: line 1 column 1'):
+    with pytest.raises_regexp(AppError,
+                              'Expecting value: line 1 column 1'):
         app.post('/request_echo', '<a>', headers=headers)
-    with pytest.raises_regexp(AppError, ('Expecting property name enclosed in'
-                                         ' double quotes: line 1 column 2')):
+    with pytest.raises_regexp(AppError,
+                              'Expecting property name enclosed in'
+                              ' double quotes: line 1 column 2'):
         app.post('/request_echo', '{', headers=headers)
 
 

--- a/spynl/tests/test_schema.py
+++ b/spynl/tests/test_schema.py
@@ -5,9 +5,7 @@
 import json
 import os
 from copy import deepcopy
-
 import pytest
-from pyramid import testing
 
 from spynl.main.validation import interprete_validation_instructions as validate_json
 from spynl.main.exceptions import BadValidationInstructions, InvalidResponse
@@ -21,12 +19,6 @@ PING_SCHEMA = {"$schema": "http://json-schema.org/schema#",
                "properties": {"status": {"type": "string"},
                               "greeting": {"type": "string"},
                               "time": {"type": "string"}}}
-
-@pytest.fixture
-def config():
-    configurator = testing.setUp(settings={'spynl.schemas': 'spynl-schemas'})
-    yield configurator
-    testing.tearDown()
 
 
 @pytest.fixture(autouse=True)
@@ -75,7 +67,7 @@ def invalid_schema(tmpdir):
     file_.remove()
 
 
-def test_novalidations_possible(config, invalid_schema):
+def test_novalidations_possible(invalid_schema):
     """Test cases where no validations are possible."""
     invalid_ping_response = deepcopy(USUAL_PING_RESPONSE)
     del invalid_ping_response['greeting']
@@ -115,13 +107,13 @@ def test_invalid_description(ping_schema):
         validate_json(USUAL_PING_RESPONSE, vals, 'response')
 
 
-def test_correct_response_schema(config, ping_schema):
+def test_correct_response_schema(ping_schema):
     """Test validating a usual ping reponse."""
     vals = [{'schema': ping_schema.basename, 'in': 'response'}]
     validate_json(USUAL_PING_RESPONSE, vals, 'response')
 
 
-def test_correct_sub_schema(config, ping_schema, tenants_schema):
+def test_correct_sub_schema(ping_schema, tenants_schema):
     """Test usual ping with tenants."""
     vals = [{'schema': ping_schema.basename, 'in': 'response'},
             {'schema': tenants_schema.basename, 'in': 'response',
@@ -132,14 +124,14 @@ def test_correct_sub_schema(config, ping_schema, tenants_schema):
     validate_json(ping_response_with_tenants, vals, 'response')
 
 
-def test_incorrect_response_schema(config, wrong_ping_schema):
+def test_incorrect_response_schema(wrong_ping_schema):
     """Change schema so that the /ping response is not correct."""
     vals = [{'schema': wrong_ping_schema.basename, 'in': 'response'}]
     with pytest.raises_regexp(InvalidResponse, "'di' is a required property"):
         validate_json(USUAL_PING_RESPONSE, vals, 'response')
 
 
-def test_incorrect_sub_schema(config, ping_schema, tenants_schema):
+def test_incorrect_sub_schema(ping_schema, tenants_schema):
     """Test usual ping with wrong tenant data."""
     vals = [{'schema': ping_schema.basename, 'in': 'response'},
             {'schema': tenants_schema.basename, 'in': 'response',


### PR DESCRIPTION
Used git revert on the following three commits:

27e2b1a remove python-rapidjson use python's json instead
51e8cb8 add g++ to Dockerfile
f6eca5f SWPY-595 SWPY-673 SWPY-674 use rapidjson for json serialization

This puts spynl in the exact state as before the rapidjson adventure. 
(minus the unrelated commits from rosanne)