### PR TITLE
make child classes compatible with new attribute

### DIFF
--- a/spynl/main/exceptions.py
+++ b/spynl/main/exceptions.py
@@ -48,7 +48,9 @@ class SpynlException(Exception):
             'status': 'error',
             'type': self.__class__.__name__,
             'message': self.message,
-            'developer_message': self.developer_message
+            'developer_message': getattr(self,
+                                         'developer_message',
+                                         self.message)
         }
 
         return response


### PR DESCRIPTION
Many if not all already created exception classes that inherit from `SpynlException` overwrite `__init__` method so they do not know about the new attribute `developer_message` and they do not call `super`.