### PR TITLE
SPAPI-48 SpynlException subclasses should call super()

### DIFF
--- a/spynl/main/exceptions.py
+++ b/spynl/main/exceptions.py
@@ -27,8 +27,8 @@ class SpynlException(Exception):
                  developer_message=None,
                  debug_message=None):
         self.message = message
-        self.developer_message = developer_message or self.message
-        self.debug_message = debug_message or self.message
+        self.developer_message = developer_message
+        self.debug_message = debug_message
 
     def make_response(self):
         """
@@ -70,19 +70,17 @@ class BadOrigin(SpynlException):
 
     def __init__(self, origin):
         """Set the origin attribute."""
-        self.origin = origin
-        self.message = _(u'bad-origin',
-                         default="Requests to the Spynl API are not "
-                         "permitted from origin '${origin}'.",
-                         mapping={'origin': self.origin})
+        message = _(u'bad-origin',
+                    default=("Requests to the Spynl API are not "
+                             "permitted from origin '${origin}'."),
+                    mapping={'origin': origin})
+        super().__init__(message=message)
 
 
 class IllegalAction(SpynlException):
     """Raise if the desired action is not allowed."""
 
-    def __init__(self, message):
-        """Exception message."""
-        self.message = message
+    pass
 
 
 class MissingParameter(SpynlException):
@@ -90,9 +88,10 @@ class MissingParameter(SpynlException):
 
     def __init__(self, param):
         """Exception message."""
-        self.message = _('missing-parameter',
-                         default='Missing required parameter: ${param}',
-                         mapping={'param': param})
+        message = _('missing-parameter',
+                    default='Missing required parameter: ${param}',
+                    mapping={'param': param})
+        super().__init__(message=message)
 
 
 class IllegalParameter(SpynlException):
@@ -100,9 +99,10 @@ class IllegalParameter(SpynlException):
 
     def __init__(self, param):
         """Exception message."""
-        self.message = _('illegal-parameter',
-                         default='Illegal parameter: ${param}',
-                         mapping={'param': param})
+        message = _('illegal-parameter',
+                    default='Illegal parameter: ${param}',
+                    mapping={'param': param})
+        super().__init__(message=message)
 
 
 class BadValidationInstructions(SpynlException):
@@ -110,10 +110,13 @@ class BadValidationInstructions(SpynlException):
 
     def __init__(self, error):
         """Exception message."""
-        self.message = _('bad-validation-instructions',
-                         default='The description of validations for this'
-                         ' endpoint cannot be used: ${error}',
-                         mapping={'error': error})
+        message = _(
+            'bad-validation-instructions',
+            default=('The description of validations for this endpoint cannot '
+                     'be used: ${error}'),
+            mapping={'error': error}
+        )
+        super().__init__(message=message)
 
 
 class InvalidResponse(SpynlException):
@@ -121,9 +124,12 @@ class InvalidResponse(SpynlException):
 
     def __init__(self, error):
         """Exception message."""
-        self.message = _('invalid-response',
-                         default='Spynl could not generate a valid response: ${error}',
-                         mapping={'error': error})
+        message = _(
+            'invalid-response',
+            default=('Spynl could not generate a valid response: ${error}'),
+            mapping={'error': error}
+        )
+        super().__init__(message=message)
 
 
 class EmailTemplateNotFound(SpynlException):
@@ -131,9 +137,12 @@ class EmailTemplateNotFound(SpynlException):
 
     def __init__(self, template):
         """Exception message."""
-        self.message = _('email-tmpl-not-found',
-                         default='The email template <${template}> was not found.',
-                         mapping={'template': template})
+        message = _(
+            'email-tmpl-not-found',
+            default=('The email template <${template}> was not found.'),
+            mapping={'template': template}
+        )
+        super().__init__(message=message)
 
 
 class EmailRecipientNotGiven(SpynlException):
@@ -141,5 +150,6 @@ class EmailRecipientNotGiven(SpynlException):
 
     def __init__(self):
         """Exception message."""
-        self.message = _('email-recipient-not-given',
-                         default='You did not give a recipient for the email.')
+        message = _('email-recipient-not-given',
+                    default=('You did not give a recipient for the email.'))
+        super().__init__(message=message)

--- a/spynl/main/serial/csv.py
+++ b/spynl/main/serial/csv.py
@@ -34,7 +34,8 @@ def loads(body, headers={}, context=None):
             if str(err) == 'Could not determine delimiter':
                 dialect = csv.Sniffer().sniff(body[:6000], delimiters=',\t|')
             else:
-                raise MalformedRequestException('text/csv', str(err))
+                raise MalformedRequestException('text/csv',
+                                                error_cause=str(err))
 
         if not delimiter:
             delimiter = dialect.delimiter

--- a/spynl/main/serial/exceptions.py
+++ b/spynl/main/serial/exceptions.py
@@ -1,4 +1,4 @@
-"""Custom (de)serialisation Exceptions"""
+"""Custom (de)serialisation Exceptions."""
 
 
 from spynl.main.exceptions import SpynlException
@@ -6,61 +6,64 @@ from spynl.main.locale import SpynlTranslationString as _
 
 
 class UndeterminedContentTypeException(SpynlException):
-    """Undetermined Content Type"""
+    """Undetermined Content Type."""
 
     def __init__(self):
-        """Exception message"""
-        self.message =  _('undetermined-content-type-exception',
-                          default='The request carries a body but the content type cannot be '
-                          'determined.')
+        """Exception message."""
+        message = _('undetermined-content-type-exception',
+                    default=('The request carries a body but the '
+                             'content type cannot be determined.'))
+        super().__init__(message=message)
 
 
 class UnsupportedContentTypeException(SpynlException):
-    """Unsupported Content Type"""
+    """Unsupported Content Type."""
 
     def __init__(self, content_type):
-        """Exception message"""
-        self.message =  _('unsupported-content-type-exception',
-                          default='Unsupported content type: "${type}"',
-                          mapping={'type': content_type})
+        """Exception message."""
+        message = _('unsupported-content-type-exception',
+                    default='Unsupported content type: "${type}"',
+                    mapping={'type': content_type})
+        super().__init__(message=message)
 
 
 class DeserializationUnsupportedException(SpynlException):
-    """Deserialisation not supported"""
+    """Deserialisation not supported."""
 
     def __init__(self, content_type):
-        """Exception message"""
-        self.message = _('deserialization-unsupported-exception',
-                         default='Deserialization for content type "${type}" is '
-                         'unsupported.',
-                         mapping={'type': content_type})
+        """Exception message."""
+        message = _('deserialization-unsupported-exception',
+                    default=('Deserialization for content type '
+                             '"${type}" is unsupported.'),
+                    mapping={'type': content_type})
+        super().__init__(message=message)
 
 
 class SerializationUnsupportedException(SpynlException):
-    """Serialization not supported"""
+    """Serialization not supported."""
 
     def __init__(self, content_type):
-        """Exception message"""
-        self.message = _('serialization-unsupported-exception',
-                         default='Serialization for content type: "${type}" is '
-                         'not supported.',
-                         mapping={'type': content_type})
-        return _('serialization-unsupported-exception',
-                 default='Serialization for content type: "${type}" is '
-                         'not supported.',
-                 mapping={'type': self.args[0]})
+        """Exception message."""
+        message = _('serialization-unsupported-exception',
+                    default=('Serialization for content type: '
+                             '"${type}" is not supported.'),
+                    mapping={'type': content_type})
+        super().__init__(message=message)
 
 
 class MalformedRequestException(SpynlException):
-    """Malformed reqeust - first give content type, then message"""
+    """Malformed reqeust - first give message then content type."""
 
-    def __init__(self, content_type, request=None):
-        """Exception message"""
-        if request:
-            self.message = _('malformed-request-exception-type',
-                             default='Malformed "${type}" request: ${request}',
-                             mapping={'type': content_type, 'request': request})
+    def __init__(self, content_type, error_cause=None):
+        """Exception message."""
+        if error_cause:
+            message = _('malformed-request-exception-type',
+                        default=('Malformed "${type}" request: '
+                                 '${request}'),
+                        mapping={'type': content_type,
+                                 'request': error_cause})
         else:
-            self.message = _('malformed-request-exception',
-                             default='Malformed request: ${type}',
-                             mapping={'type': content_type})
+            message = _('malformed-request-exception',
+                        default='Malformed request: ${type}',
+                        mapping={'type': content_type})
+        super().__init__(message=message)

--- a/spynl/main/serial/json.py
+++ b/spynl/main/serial/json.py
@@ -12,8 +12,9 @@ def loads(body, headers=None, context=None):
     try:
         decoder = objects.SpynlDecoder(context)
         return json.loads(body, object_hook=decoder)
-    except ValueError as e:
-        raise MalformedRequestException('application/json', str(e))
+    except ValueError as err:
+        raise MalformedRequestException('application/json',
+                                        error_cause=str(err))
 
 
 def dumps(body, pretty=False):

--- a/spynl/main/serial/xml.py
+++ b/spynl/main/serial/xml.py
@@ -15,9 +15,10 @@ def loads(body, headers=None, context=None):
     """return body as XML"""
     try:
         root = fromstring(body)
-    except ParseError as e:
+    except ParseError as err:
         # pylint: disable=E1101
-        raise MalformedRequestException('application/xml', str(e))
+        raise MalformedRequestException('application/xml',
+                                        error_cause=str(err))
 
     dic = __loads(root, True)
     return objects.SpynlDecoder(context=context)(dic)

--- a/spynl/main/serial/yaml.py
+++ b/spynl/main/serial/yaml.py
@@ -27,5 +27,6 @@ def loads(body, headers=None):
     """return body as YAML"""
     try:
         return yaml.load(body)
-    except ValueError as e:
-        raise MalformedRequestException('application/x-yaml', str(e))
+    except ValueError as err:
+        raise MalformedRequestException('application/x-yaml',
+                                        error_cause=str(err))

--- a/spynl/main/utils.py
+++ b/spynl/main/utils.py
@@ -467,11 +467,13 @@ def log_error(exc, request, top_msg, error_type=None, error_msg=None):
 
     user_info = get_user_info(request, purpose='error_view')
 
-    metadata = dict(user=user_info,
-                    url=request.path_url,
-                    debug_message=getattr(exc, 'debug_message', 'No debug message'),
-                    err_source=get_err_source(last_traceback),
-                    detail=getattr(exc, 'detail', None))
+    metadata = dict(
+        user=user_info,
+        url=request.path_url,
+        debug_message=getattr(exc, 'debug_message', 'No debug message'),
+        err_source=get_err_source(last_traceback),
+        detail=getattr(exc, 'detail', None)
+    )
 
     log.error(top_msg,
               error_type,


### PR DESCRIPTION
In `spynl/main/utils.py` line: 473, I call explicitly `str()` because a translation string object was ended up in `debug_message` attribute and cause some tests to fail(because that object couldn't be parsed).
Now I am not sure at which point we call either `.translate()` to get the translated exception message or `str()` to get the interpolated message before we give the response to user.

Maybe I need to update the PR including the `SpynlException.make_response()` aware of translation objects? @RosanneZe, @Kareeeeem your thoughts?