### PR TITLE
fix adding newlines in links in text version of email

### DIFF
--- a/spynl/main/mail.py
+++ b/spynl/main/mail.py
@@ -175,6 +175,7 @@ def send_template_email(request, recipient, template_string=None,
 
     text_maker = html2text.HTML2Text()
     text_maker.ignore_images = True
+    text_maker.wrap_links = False
     text_body = text_maker.handle(html_body)
 
     text_body = Attachment(data=text_body, transfer_encoding="base64",


### PR DESCRIPTION
While working on another ticket I realized that the links break cause of html2text adding new lines. It adds new lines because the attribute `.body_width` is by default ~72(i dont remember the excact number)