### PR TITLE
SPAPI-73 Get the locale setting from the user

### DIFF
--- a/spynl/main/events.py
+++ b/spynl/main/events.py
@@ -10,7 +10,7 @@ from pyramid.events import (NewRequest, BeforeTraversal, ContextFound,
 from pyramid.httpexceptions import HTTPUnsupportedMediaType
 
 from spynl.main.utils import (unify_args, get_logger, is_origin_allowed,
-                              get_settings)
+                              validate_locale)
 from spynl.main.serial.typing import negotiate_request_content_type
 from spynl.main.serial.exceptions import UnsupportedContentTypeException
 
@@ -33,7 +33,7 @@ def prepare_content_types(event):
     # Overwrite the HTML assumption made by the browsers
     # about response type with the Spynl default, views can overwrite
     if request.response.content_type == 'text/html'\
-      and '/static' not in request.path_url:
+            and '/static' not in request.path_url:
         request.response.content_type = 'application/json'
 
 
@@ -79,38 +79,16 @@ def store_accepted_lang(event):
     "en-gb" will be treated as "en".
 
     We look for information about the locale in this order:
-    1. The "lang" cookie
+    1. The "_LOCALE_" cookie
     2. The request header Accept-language
     3. The first of the supported languages (spynl.languages)
     4. We fall back to "en", which is the language the code uses
     """
-    request = event.request
-    settings = get_settings()
 
-    language = None
-
-    def langcode(langstr):
-        """return only up to the first two characters"""
-        if len(langstr) < 2:
-            return langstr
-        return langstr[:2]
-
-    supported_languages = [langcode(lang.strip()) for lang in
-                           settings.get('spynl.languages', '').split(',')]
-    preferred_language = supported_languages[0]
-
-    if 'lang' in request.cookies:
-        language = langcode(request.cookies['lang'])
-    elif request.accept_language:
-        language = langcode(request.accept_language\
-                                   .best_match(supported_languages,
-                                               preferred_language))
-    if language is None or language not in supported_languages:
-        language = preferred_language
-    if language is None:
-        language = 'en'
-    # pylint: disable=W0212
-    request._LOCALE_ = language
+    try:
+        event.request._LOCALE_ = validate_locale(event.request.cookies['_LOCALE_'])
+    except KeyError:
+        event.request._LOCALE_ = validate_locale(event.request.accept_language)
 
 
 def parse_args_and_log_request(event):

--- a/spynl/main/events.py
+++ b/spynl/main/events.py
@@ -79,14 +79,14 @@ def store_accepted_lang(event):
     "en-gb" will be treated as "en".
 
     We look for information about the locale in this order:
-    1. The "_LOCALE_" cookie
+    1. The "lang" cookie
     2. The request header Accept-language
     3. The first of the supported languages (spynl.languages)
     4. We fall back to "en", which is the language the code uses
     """
 
     try:
-        event.request._LOCALE_ = validate_locale(event.request.cookies['_LOCALE_'])
+        event.request._LOCALE_ = validate_locale(event.request.cookies['lang'])
     except KeyError:
         event.request._LOCALE_ = validate_locale(event.request.accept_language)
 

--- a/spynl/main/utils.py
+++ b/spynl/main/utils.py
@@ -60,6 +60,23 @@ def check_origin(endpoint, info):
     return wrapper_view
 
 
+def validate_locale(locale):
+    """Validate a locale against our supported languages."""
+    supported_languages = [
+        lang.strip() for lang in
+        get_settings().get('spynl.languages', 'en').split(',')
+    ]
+    language = None
+
+    if not locale:
+        return
+
+    # we're only looking for languages here, not dialects.
+    language = str(locale)[:2]
+    if language in supported_languages:
+        return language
+
+
 def handle_pre_flight_request(endpoint, info):
     """
     "pre-flight-request": return custom response with some information on

--- a/spynl/main/utils.py
+++ b/spynl/main/utils.py
@@ -63,7 +63,7 @@ def check_origin(endpoint, info):
 def validate_locale(locale):
     """Validate a locale against our supported languages."""
     supported_languages = [
-        lang.strip() for lang in
+        lang.strip().lower() for lang in
         get_settings().get('spynl.languages', 'en').split(',')
     ]
     language = None
@@ -72,7 +72,7 @@ def validate_locale(locale):
         return
 
     # we're only looking for languages here, not dialects.
-    language = str(locale)[:2]
+    language = str(locale)[:2].lower()
     if language in supported_languages:
         return language
 

--- a/spynl/tests/conftest.py
+++ b/spynl/tests/conftest.py
@@ -24,6 +24,7 @@ def settings():
             'pyramid.reload_templates': 'true',
             'spynl.domain': 'localhost',
             'spynl.languages': 'en,nl',
+            'default_locale_name': 'nl',
             'spynl.schemas': 'spynl-schemas',
             'pyramid.debug_notfound': 'false',
             'pyramid.debug_templates': 'true',

--- a/spynl/tests/test_origin_whitelists.py
+++ b/spynl/tests/test_origin_whitelists.py
@@ -24,12 +24,13 @@ def test_whitelisted_origin(app):
 
 def test_notwhitelisted_origin(app):
     """Test not whitelisted origin."""
-    headers = {"Origin": "Not-a-Url", "Content-Type": "application/json"}
-    with pytest.raises_regexp(HTTPForbidden, "not permitted from origin 'Not-a-Url'"):
+    msg = 'Requests naar Spynl zijn niet toegestaan vanaf origin '
+    headers = {"Origin": "Not-a-Url", "Content-Type": "application/json'"}
+    with pytest.raises_regexp(HTTPForbidden, msg + "'Not-a-Url"):
         app.get('/ping', headers=headers)
     headers = {"Origin": "http://www.swcloud.com"}
-    with pytest.raises_regexp(HTTPForbidden, "not permitted from origin 'http://www.swcloud.com'"):
+    with pytest.raises_regexp(HTTPForbidden, msg + "'http://www.swcloud.com'"):
         app.get('/ping', headers=headers)
     headers = {"Origin": "http://0.0.0.0:9003"}
-    with pytest.raises_regexp(HTTPForbidden, "not permitted from origin 'http://0.0.0.0:9003'"):
+    with pytest.raises_regexp(HTTPForbidden, msg + "'http://0.0.0.0:9003'"):
         app.get('/ping', headers=headers)

--- a/spynl/tests/test_responses.py
+++ b/spynl/tests/test_responses.py
@@ -46,7 +46,7 @@ def test_get_req_dont_parse_body(app):
 
 def test_contenttype_unsupported(app):
     """Raise exception when conttenttype is unsupported."""
-    with pytest.raises_regexp(AppError, 'Unsupported content type'):
+    with pytest.raises_regexp(AppError, 'Content type is niet ondersteund'):
         app.post('/request_echo', 'wtf',
                  headers={'Content-Type': 'text/plain'})
 

--- a/spynl/tests/test_translations.py
+++ b/spynl/tests/test_translations.py
@@ -16,8 +16,8 @@ def reset_app(app):
 
 
 @pytest.mark.parametrize("method,language", [
-    (None, 'en'),
-    ('cookie', 'nl'),
+    (None, 'nl'),
+    ('cookie', 'en'),
     ('header', 'nl'),
     ('setting', 'nl')
 ])
@@ -25,9 +25,9 @@ def test_response_message(app, app_factory, method, language, settings):
     """Test /about, with various methods of specifying the language"""
     headers = {}
     if method == 'cookie':
-        app.set_cookie('lang', 'nl-nl')
+        app.set_cookie('_LOCALE_', 'en-GB')
     elif method == 'header':
-        headers = {'Accept-language': 'nl'}
+        headers = {'Accept-Language': 'nl'}
     elif method == 'setting':
         settings['spynl.languages'] = 'nl,en'
         app = app_factory(settings)

--- a/spynl/tests/test_translations.py
+++ b/spynl/tests/test_translations.py
@@ -25,7 +25,7 @@ def test_response_message(app, app_factory, method, language, settings):
     """Test /about, with various methods of specifying the language"""
     headers = {}
     if method == 'cookie':
-        app.set_cookie('_LOCALE_', 'en-GB')
+        app.set_cookie('lang', 'en-GB')
     elif method == 'header':
         headers = {'Accept-Language': 'nl'}
     elif method == 'setting':


### PR DESCRIPTION
This PR introduces a number of changes. The cookie we are settings for
language is now called _LOCALE_ as per pyramid suggestions.

We no longer explicitly set in the code a default as pyramid already
has a setting for this in the ini pyramid.default_locale_name

The validation of locales is extracted so other parts of the code can
call it and do what they want with the output.